### PR TITLE
Fix 2 code scanning alerts

### DIFF
--- a/WebGoat/Content/HeaderInjection.aspx.cs
+++ b/WebGoat/Content/HeaderInjection.aspx.cs
@@ -6,7 +6,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Collections;
 using System.Collections.Specialized;
-
+using System.Net;
 namespace OWASP.WebGoat.NET
 {
     public partial class HeaderInjection : System.Web.UI.Page
@@ -30,7 +30,7 @@ namespace OWASP.WebGoat.NET
 
 
             //Headers
-            lblHeaders.Text = Request.Headers.ToString().Replace("&", "<br />");
+            lblHeaders.Text = WebUtility.HtmlEncode(Request.Headers.ToString()).Replace("&", "<br />");
 
             //Cookies
             ArrayList colCookies = new ArrayList();

--- a/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
+++ b/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
@@ -23,9 +23,10 @@ namespace OWASP.WebGoat.NET.WebGoatCoins
             //context.Response.Write("Hello World");
 
             string query = context.Request["query"];
+            string encodedQuery = System.Net.WebUtility.HtmlEncode(query);
             
-            DataSet ds = du.GetCustomerEmails(query);
-            string json = Encoder.ToJSONSAutocompleteString(query, ds.Tables[0]);
+            DataSet ds = du.GetCustomerEmails(encodedQuery);
+            string json = Encoder.ToJSONSAutocompleteString(encodedQuery, ds.Tables[0]);
 
             if (json != null && json.Length > 0)
             {


### PR DESCRIPTION
Fixes 2 code scanning alerts:
- https://github.com/charlie-vulns/advanced-security-csharp/security/code-scanning/15
To fix the problem, we need to sanitize the user-controlled data before writing it to the HTML. The best way to do this is by using the `System.Net.WebUtility.HtmlEncode` method, which will encode the headers and prevent any malicious scripts from being executed. This change should be made on line 33 where the headers are being written to the HTML.
  


- https://github.com/charlie-vulns/advanced-security-csharp/security/code-scanning/19
To fix the problem, we need to ensure that the user-provided input is properly sanitized before it is written to the response. The best way to do this is to use the `System.Net.WebUtility.HtmlEncode` method to encode the `query` parameter before it is used in the `Encoder.ToJSONSAutocompleteString` method. This will prevent any malicious input from being executed as part of the response.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._