### PR TITLE
Potential fix for code scanning alert no. 18: Cross-site scripting

### DIFF
--- a/WebGoat/Content/VerbTamperingAttack.aspx.cs
+++ b/WebGoat/Content/VerbTamperingAttack.aspx.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Web;
+using System.Net;
 using System.Web.UI;
 
 namespace OWASP.WebGoat.NET
@@ -11,7 +12,7 @@ namespace OWASP.WebGoat.NET
         {
             if (Request.QueryString["message"] != null)
             {
-                VerbTampering.tamperedMessage = Request.QueryString["message"];
+                VerbTampering.tamperedMessage = System.Net.WebUtility.HtmlEncode(Request.QueryString["message"]);
             }
         } 
     }


### PR DESCRIPTION
Potential fix for [https://github.com/charlie-vulns/advanced-security-csharp/security/code-scanning/18](https://github.com/charlie-vulns/advanced-security-csharp/security/code-scanning/18)

To fix the cross-site scripting vulnerability, we need to sanitize the user input before it is assigned to the `tamperedMessage` variable. The best way to do this is by using the `System.Net.WebUtility.HtmlEncode` method, which will encode the input and prevent any malicious scripts from being executed when the content is rendered on the webpage.

We will modify the `WebGoat/Content/VerbTamperingAttack.aspx.cs` file to sanitize the `Request.QueryString["message"]` before assigning it to `VerbTampering.tamperedMessage`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
