### PR TITLE
Potential fix for code scanning alert no. 30: 'requireSSL' attribute is not set to true

### DIFF
--- a/WebGoat/Web.config
+++ b/WebGoat/Web.config
@@ -42,7 +42,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
     <!-- this disables header checking -->
     <httpRuntime enableHeaderChecking="false" />
     <!-- this is how you would set secure and http only on session cookies -->
-    <httpCookies httpOnlyCookies="false" requireSSL="false" />
+    <httpCookies httpOnlyCookies="false" requireSSL="true" />
     <compilation defaultLanguage="C#" debug="true">
       <assemblies>
         <!--add assembly="System.Web.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" /-->
@@ -53,7 +53,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
     <customErrors mode="Off" />
     <!-- set up users -->
     <authentication mode="Forms">
-      <forms name="customer_login" timeout="30" loginUrl="~/WebGoatCoins/CustomerLogin.aspx" requireSSL="false" protection="All" path="/">
+      <forms name="customer_login" timeout="30" loginUrl="~/WebGoatCoins/CustomerLogin.aspx" requireSSL="true" protection="All" path="/">
         <credentials passwordFormat="Clear">
           <user name="admin" password="admin" />
           <user name="mario" password="luigi" />


### PR DESCRIPTION
Potential fix for [https://github.com/charlie-vulns/advanced-security-csharp/security/code-scanning/30](https://github.com/charlie-vulns/advanced-security-csharp/security/code-scanning/30)

To fix the problem, we need to set the `requireSSL` attribute to `true` in both the `<forms>` and `<httpCookies>` elements within the `Web.config` file. This ensures that sensitive data transmitted via forms and cookies is encrypted using SSL/TLS.

- Locate the `<forms>` element within the `<authentication>` section and set the `requireSSL` attribute to `true`.
- Locate the `<httpCookies>` element within the `<system.web>` section and set the `requireSSL` attribute to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
